### PR TITLE
Added more options to vm.create

### DIFF
--- a/lib/rvc/modules/vm.rb
+++ b/lib/rvc/modules/vm.rb
@@ -105,6 +105,8 @@ opts :create do
   opt :host, "Host", :short => 'h', :type => :string, :lookup => VIM::HostSystem
   opt :datastore, "Datastore", :short => 'd', :type => :string, :lookup => VIM::Datastore
   opt :disksize, "Size in KB of primary disk", :short => 's', :type => :int, :default => 4000000
+  opt :memory, "Size in MB of memory", :short => 'm', :type => :int, :default => 128
+  opt :cpucount, "Number of CPUs", :short => 'c', :type => :int, :default => 1
 end
 
 def create dest, opts
@@ -116,8 +118,8 @@ def create dest, opts
     :name => name,
     :guestId => 'otherGuest',
     :files => { :vmPathName => datastore_path },
-    :numCPUs => 1,
-    :memoryMB => 128,
+    :numCPUs => opt[:cpucount],
+    :memoryMB => opt[:memory],
     :deviceChange => [
       {
         :operation => :add,


### PR DESCRIPTION
You can now do specify primary disksize, memory and cpucount:

/soko.puppetlabs.lan/ha-datacenter/vm> help vm.create
usage: vm.create [opts] name
Create a new VM
  name: Destination Folder
       --pool, -p <s>:   Resource pool
       --host, -h <s>:   Host
  --datastore, -d <s>:   Datastore
   --disksize, -s <i>:   Size in KB of primary disk (default: 4000000)
     --memory, -m <i>:   Size in MB of memory (default: 128)
   --cpucount, -c <i>:   Number of CPUs (default: 1)
