### PR TITLE
A couple of useful fixes for vm.create that I've penned.

### DIFF
--- a/lib/rvc/modules/vm.rb
+++ b/lib/rvc/modules/vm.rb
@@ -143,6 +143,7 @@ end
 def create dest, opts
   err "must specify resource pool (--pool)" unless opts[:pool]
   err "must specify datastore (--datastore)" unless opts[:datastore]
+  err "memory must be a multiple of 4MB" unless opts[:memory] % 4 == 0
   vmFolder, name = *dest
   datastore_path = "[#{opts[:datastore].name}]"
   config = {


### PR DESCRIPTION
- now works with --size 1g.
- trollop output has an example.
- enforces memory being a multiple of 4.
