### PR TITLE
Backport input checks for memory resizing on VMs

### DIFF
--- a/lib/rvc/modules/vm.rb
+++ b/lib/rvc/modules/vm.rb
@@ -703,6 +703,8 @@ opts :modify_memory do
 end
 
 def modify_memory vm, opts
+  err "VM needs to be off" unless vm.summary.runtime.powerState == 'poweredOff'
+  err "memory must be a multiple of 4MB" unless ( opts[:size]  % 4 ) == 0
   spec = { :memoryMB => opts[:size] }
   tasks [vm], :ReconfigVM, :spec => spec
 end


### PR DESCRIPTION
just checks for 4mb multiple and that the VM is shutdown.
