### PR TITLE
Allow specifying port number on command-line

### DIFF
--- a/lib/rvc/modules/vim.rb
+++ b/lib/rvc/modules/vim.rb
@@ -47,11 +47,10 @@ def connect uri, opts
   match = URI_REGEX.match uri
   Trollop.die "invalid hostname" unless match
 
-  pp match
   username = match[1] || ENV['RBVMOMI_USER']
   password = match[2] || ENV['RBVMOMI_PASSWORD']
   host = match[3]
-  port = if match[4] then match[4] else 443 end
+  port = match[4] || 443
   path = match[5]
   bad_cert = false
 


### PR DESCRIPTION
Like so: `rvc Administrator@vc-server:443`

fixes #17
