### PR TITLE
Add datastore.findOrphans command.

### DIFF
--- a/lib/rvc/modules/datastore.rb
+++ b/lib/rvc/modules/datastore.rb
@@ -163,3 +163,104 @@ end
 def http_path dc_name, ds_name, path
   "/folder/#{URI.escape path}?dcPath=#{URI.escape dc_name}&dsName=#{URI.escape ds_name}"
 end
+
+
+opts :findOrphans do
+  summary "Finds directories on the datastore that don't belong to any registered VM"
+  arg :ds, nil, :lookup => VIM::Datastore
+end
+
+def findOrphans ds
+  pc = ds._connection.serviceContent.propertyCollector
+  vms = ds.vm
+  
+  times = []
+  times << Time.now
+  puts "Collecting file information about #{vms.length} VMs ... (this may take a while)"
+  dsName = ds.name
+  vmFiles = pc.collectMultiple vms, 'layoutEx.file'
+  
+  times << Time.now
+  puts "Collecting file information on datastore '#{dsName}' ..."
+  dsBrowser = ds.browser
+  result = dsBrowser.SearchDatastore_Task(
+    :datastorePath => "[#{dsName}] ",
+    :searchSpec => {
+      :details => {
+        :fileType => true,
+        :fileSize => false,
+        :fileOwner => false,
+        :modification => false
+      }
+    }
+  ).wait_for_completion
+  dsDirectories = result.file.select{|x| x.is_a?(RbVmomi::VIM::FolderFileInfo)}.map{|x| x.path}
+  
+  times << Time.now
+  puts "Checking for any VMs that got added inbetween ..."
+  addedVms = ds.vm - vms
+  if addedVms.length > 0
+    puts "Processing #{addedVms.length} new VMs ..."
+    vmFiles.merge!(pc.collectMultiple addedVms, 'layoutEx.file')
+  end
+
+  times << Time.now
+  puts "Cross-referencing VM files with files on datastore '#{dsName}' ..."
+  vmFilenameHash = Hash[vmFiles.map do |vm, info| 
+    [
+      vm, 
+      info["layoutEx.file"].map{|x| x.name}.select{|x| x =~ /^\[#{dsName}\] /}.map{|x| x.gsub(/^\[#{dsName}\] /, '')}
+    ]
+  end]
+  filenames = []
+  vmFilenameHash.each do |vm, list|
+    filenames += list
+  end
+  vmDirectories = filenames.map{|x| x.split('/').first}.uniq
+  orphanDirectories = (dsDirectories - vmDirectories)
+  puts "Found #{orphanDirectories.length} potentially orphaned directories"
+  
+  puts "Composing list of potentially orphaned files ... (this may take a while)"
+  table = orphanDirectories.map do |dir|
+    begin 
+      result = dsBrowser.SearchDatastoreSubFolders_Task(
+        :datastorePath => "[#{dsName}] #{dir}/",
+        :searchSpec => {
+          :details => {
+            :fileType => false,
+            :fileSize => true,
+            :fileOwner => false,
+            :modification => false
+          }
+        }
+      ).wait_for_completion
+      # pp result
+      files = result.map{|y| y.file}.flatten
+      dirSize = files.map{|x| x.fileSize}.sum
+      $stdout.write "."
+      $stdout.flush
+      [dir, dirSize, files.length]
+    rescue 
+      pp dir
+      nil
+    end
+  end.select{|x| x != nil}
+  puts ""
+  puts ""
+  
+  # Should likely use a lib for this
+  puts ("-" * (2+60+3+7+6+3+10))
+  table.sort{|a,b| a[1] <=> b[1]}.each do |x|
+    dir, dirSize, numFiles = x
+    dirSizeGB = dirSize.to_f / 1024 / 1024 / 1024
+    puts(sprintf("| %-60s | %7.2f GB | %3d file(s) |", dir, dirSizeGB, numFiles))
+  end
+  puts ("-" * (2+60+3+7+6+3+10))
+  
+  times << Time.now
+
+  # (1...times.length).each do |i|
+    # puts "%.2f sec" % (times[i] - times[i - 1]).to_f
+  # end
+end
+


### PR DESCRIPTION
Add datastore.findOrphans command. It finds directories not in use by any registered VM. Very useful to find leftover VMs that didn't properly get cleaned up
