### PR TITLE
Update the OSX Keychain support to work on Lion as well as Snow Leopard.

### DIFF
--- a/lib/rvc/modules/vim.rb
+++ b/lib/rvc/modules/vim.rb
@@ -165,7 +165,7 @@ def prompt_password
 end
 
 def keychain_password username , hostname
-   return nil unless RbConfig::CONFIG['host_os'] =~ /^darwin10/
+   return nil unless RbConfig::CONFIG['host_os'] =~ /^darwin1[01]/
 
   begin
     require 'osx_keychain'


### PR DESCRIPTION
Other MacOSi could be supported, but I've not tested it on any of them,
it's just a single regex that does the OS checking, nothing more concrete.
