### PR TITLE
Fixed issue with SIGCHLD on Windows.

### DIFF
--- a/bin/rvc
+++ b/bin/rvc
@@ -159,11 +159,13 @@ if $interactive
   CMD.basic.ls RVC::Util.lookup_single('.') unless $opts[:quiet]
 end
 
-trap "SIGCHLD" do |sig|
-  begin
-    while pid = Process.wait(-1, Process::WNOHANG)
+if Signal.list["CHLD"]
+  trap "SIGCHLD" do |sig|
+    begin
+      while pid = Process.wait(-1, Process::WNOHANG)
+      end
+    rescue Errno::ECHILD
     end
-  rescue Errno::ECHILD
   end
 end
 


### PR DESCRIPTION
When running on Windows, I got the following error:

C:/Ruby192/lib/ruby/gems/1.9.1/gems/rvc-1.6.0/bin/rvc:161:in `trap':
unsupported
signal SIGCHLD (ArgumentError)
from C:/Ruby192/lib/ruby/gems/1.9.1/gems/rvc-1.6.0/bin/rvc:161:in`<top
(required)>'
from C:/Ruby192/bin/rvc:19:in `load'
from C:/Ruby192/bin/rvc:19:in`<main>'
