### PR TITLE
Fixing issue when script_args is not specified

### DIFF
--- a/bin/rvc
+++ b/bin/rvc
@@ -51,7 +51,7 @@ EOS
   opt :create_directory, "Create the initial directory if it doesn't exist", :short => :none
   opt :cmd, "command to evaluate", :short => 'c', :multi => true, :type => :string
   opt :script, "file to execute", :short => 's', :type => :string
-  opt :script_args, "arguments to script", :short => :none, :type => :string
+  opt :script_args, "arguments to script", :short => :none, :default => "", :type => :string
   opt :cookie, "authentication cookie file", :short => 'k', :type => :string
   opt :quiet, "silence unnecessary output", :short => 'q', :default => false, :type => :boolean
 end


### PR DESCRIPTION
When running a script with RVC without script_args specified, the following error is raised:
# rvc -s /dev/null

/opt/local/lib/ruby1.9/1.9.1/shellwords.rb:33:in `shellsplit': undefined method`scan' for nil:NilClass (NoMethodError)
    from /opt/local/lib/ruby1.9/gems/1.9.1/gems/rvc-1.6.0/bin/rvc:145:in `<top (required)>'
    from /opt/local/bin/rvc:23:in`load'
    from /opt/local/bin/rvc:23:in `<main>'
