### PR TITLE
Specify domain in user name (ex: rvc "company\user"@host works now)

### DIFF
--- a/lib/rvc/modules/vds.rb
+++ b/lib/rvc/modules/vds.rb
@@ -653,7 +653,7 @@ def create_vmknic portgroup, hosts, opts
         },
         :distributedVirtualPort => VIM::DistributedVirtualSwitchPortConnection(
           :portgroupKey => portgroup.key, 
-          :switchUuid => portgroup.config.distributedVirtualSwitch.uuid,
+          :switchUuid => portgroup.config.distributedVirtualSwitch.uuid
         )
       }
     )

--- a/lib/rvc/modules/vim.rb
+++ b/lib/rvc/modules/vim.rb
@@ -34,7 +34,7 @@ rvc_alias :connect
 def connect uri, opts
   uri = RVC::URIParser.parse uri unless uri.is_a? URI
 
-  username = uri.user || ENV['RBVMOMI_USER']
+  username = URI.decode(uri.user) || ENV['RBVMOMI_USER']
   password = uri.password || ENV['RBVMOMI_PASSWORD']
   host = uri.host
   port = uri.port || 443

--- a/lib/rvc/uri_parser.rb
+++ b/lib/rvc/uri_parser.rb
@@ -43,6 +43,9 @@ class URIParser
 
   # Loosely parse a URI. This is more forgiving than a standard URI parser.
   def self.parse str
+    # Encode str so that we don't throw errors on validation.
+    str = URI.encode(str)
+  
     match = URI_REGEX.match str
     Util.err "invalid URI" unless match
 

--- a/test/test_uri.rb
+++ b/test/test_uri.rb
@@ -31,4 +31,10 @@ class UriTest < Test::Unit::TestCase
     uri = RVC::URIParser.parse "user:password@host:80"
     assert_equal "//user:password@host:80", uri.to_s
   end
+  
+  def test_user_domain
+    # We're looking for an encoded URI here.
+    uri = RVC::URIParser.parse "COMPANY\\user:password@host"
+    assert_equal "//COMPANY%5Cuser:password@host", uri.to_s
+  end
 end


### PR DESCRIPTION
URI fix for domains on vim module.
Fixed syntax error on vds module.

I only included the most basic of tests to verify the URI parser is working right, being as I have absolutely no clue how you want me to test the module.

All tests pass.
