### PR TITLE
Added a clear terminal command

### DIFF
--- a/lib/rvc/modules/basic.rb
+++ b/lib/rvc/modules/basic.rb
@@ -99,6 +99,17 @@ def help_summary cmd
 end
 
 
+opts :clear do
+  summary "Clear the terminal screen"
+end
+
+rvc_alias :clear
+
+def clear
+  system("clear")
+end
+
+
 opts :debug do
   summary "Toggle VMOMI logging to stderr"
 end


### PR DESCRIPTION
I added a clear terminal command to the basic.rb module to allow users to clear their terminal screen after it starts to get cluttered from all of the commands and browsing of the file system.
