### PR TITLE
Fixed create_vmknic hosts arg and passed args to method

### DIFF
--- a/lib/rvc/modules/vds.rb
+++ b/lib/rvc/modules/vds.rb
@@ -636,10 +636,10 @@ end
 opts :create_vmknic do
   summary "Create a vmknic on vDS on one or more hosts. Always uses DHCP"
   arg :portgroup, nil, :lookup => VIM::Network
-  arg :host, nil, :lookup => VIM::HostSystem, :multi => true
+  arg :hosts, nil, :lookup => VIM::HostSystem, :multi => true
 end
 
-def create_vmknic portgroup, hosts, opts
+def create_vmknic portgroup, hosts
   if !portgroup.is_a?(VIM::DistributedVirtualPortgroup)
     err "Legacy switches not supported yet"
   end


### PR DESCRIPTION
Attached change is to fix:

> vds.create_vmknic /vcs01.local/dc/networks/vds01/portgroups/vmk1 /vcs01.local/dc/networks/vds01/hosts/esx01.local
> ArgumentError: wrong number of arguments (2 for 3)
> /Users/flands/.rvm/gems/ruby-1.9.3-p362/gems/rvc-1.7.0/lib/rvc/modules/vds.rb:642:in `create_vmknic'
> /Users/flands/.rvm/gems/ruby-1.9.3-p362/gems/rvc-1.7.0/lib/rvc/command.rb:42:in`invoke'
> /Users/flands/.rvm/gems/ruby-1.9.3-p362/gems/rvc-1.7.0/lib/rvc/shell.rb:126:in `eval_command'
> /Users/flands/.rvm/gems/ruby-1.9.3-p362/gems/rvc-1.7.0/lib/rvc/shell.rb:73:in`eval_input'
> /Users/flands/.rvm/gems/ruby-1.9.3-p362/gems/rvc-1.7.0/bin/rvc:160:in `<top (required)>'
> /Users/flands/.rvm/gems/ruby-1.9.3-p362/bin/rvc:19:in`load'
> /Users/flands/.rvm/gems/ruby-1.9.3-p362/bin/rvc:19:in `<main>'
> /Users/flands/.rvm/gems/ruby-1.9.3-p362/bin/ruby_noexec_wrapper:14:in`eval'
> /Users/flands/.rvm/gems/ruby-1.9.3-p362/bin/ruby_noexec_wrapper:14:in `<main>'
