### PR TITLE
Add basic RelocateVM support (aka storage vMotion)

### DIFF
--- a/lib/rvc/modules/vm.rb
+++ b/lib/rvc/modules/vm.rb
@@ -535,6 +535,24 @@ def migrate vms, opts
 end
 
 
+opts :relocate do
+  summary "Relocate a VM"
+  arg :vm, nil, :lookup => VIM::VirtualMachine, :multi => true
+  opt :pool, "Resource pool", :short => 'p', :type => :string, :lookup => VIM::ResourcePool
+  opt :host, "Host", :short => 'o', :type => :string, :lookup => VIM::HostSystem
+  opt :datastore, "Datastore", :short => 'd', :type => :string, :lookup => VIM::Datastore
+end
+
+def relocate vms, opts
+  tasks vms, :RelocateVM, :spec => {
+                             :pool => opts[:pool],
+                             :host => opts[:host],
+                             :datastore => opts[:datastore]
+                         },
+                         :priority => :defaultPriority
+end
+
+
 opts :clone do
   summary "Clone a VM"
   arg :src, nil, :lookup => VIM::VirtualMachine


### PR DESCRIPTION
This makes no attempt to be clever, and only calls the RelocateVM
function with the most straightforward spec.  It's similar to the
provided vm.migrate function in that regard

Example usage:

> cd /vc/dc/computers/cluster/hosts
> /vc/dc/computers/cluster/hosts> vm.relocate -o esx2 -d esx2/datastores/esx2-datastore1 esx1/vms/vm1001
> RelocateVM vm1001: success
